### PR TITLE
Snap version of certbot performs the renewal of expired certs. Howeve…

### DIFF
--- a/tasks/apache.yml
+++ b/tasks/apache.yml
@@ -79,13 +79,13 @@
 - name: Reload apache if necessary
   meta: flush_handlers
 
-- name: Automatically renew LE certs with cron
+- name: Reload Apache to install the renewed certificates.
   cron:
     name: "Renew letsencrypt SSL certificates"
     minute: "{{ letsencrypt_renew_cron_minute }}"
     day: "{{ letsencrypt_renew_cron_day }}"
     hour: "{{ letsencrypt_renew_cron_hour }}"
-    job: "/snap/bin/certbot renew --quiet --webroot-path {{ letsencrypt_webroot }} && /usr/sbin/apachectl configtest 2>&1 | /bin/grep -v 'Syntax OK' || {{ service_binary }} {{ apache2_name }} reload"
+    job: "/usr/sbin/apachectl configtest 2>&1 | /bin/grep -v 'Syntax OK' || {{ service_binary }} {{ apache2_name }} reload"
   when: ansible_os_family == 'Debian'
   tags:
     - letsencrypt_cron

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -43,12 +43,12 @@
 - name: Reload nginx if necessary
   meta: flush_handlers
 
-- name: Automatically renew LE certs with cron
+- name: Reload nginx to install the renewed certificates
   cron:
     name: "Renew letsencrypt SSL certificates"
     minute: "{{ letsencrypt_renew_cron_minute }}"
     day: "{{ letsencrypt_renew_cron_day }}"
     hour: "{{ letsencrypt_renew_cron_hour }}"
-    job: "/snap/bin/certbot renew --quiet --webroot-path {{ letsencrypt_webroot }} && /usr/sbin/nginx -tq && {{ service_binary }} nginx reload > /dev/null"
+    job: "/usr/sbin/nginx -tq && {{ service_binary }} nginx reload > /dev/null"
   tags:
     - letsencrypt_cron


### PR DESCRIPTION
Snap version of certbot performs the renewal of expired certs. However it doesnt reload the service. So we can remove the renewal from cron and just reload the service.